### PR TITLE
Add support for exported_namespace GPU metrics filter and better logging to prom-keycloak-proxy

### DIFF
--- a/services/promService.go
+++ b/services/promService.go
@@ -19,7 +19,6 @@ func PromQueryHandler(gocloakClient *gocloak.GoCloak, authRealm string, authClie
 
 			queryValues := r.URL.Query()
 			matchers := queryValues[queries.QueryParam]
-			//v := make(url.Values)
 			for _, matcher := range matchers {
 				expr, _ := parser.ParseExpr(matcher)
 				queryValues.Set(queries.QueryParam, expr.String())


### PR DESCRIPTION
- **Add support for exported_namespace GPU metrics filter** - In order to grant namespace specific access to GPU metrics, we add support fore the exported_namespace filter, rather than just the namespace filter. More precise validation of all permission resource + scope combinations in the PromQL is evaluated before querying prometheus.
- **Add logging of client-id and service account username** - Perform a userinfo request on the Authorization header bearer token to identify the service account and client of each query to the prom-keycloak-proxy.