### PR TITLE
Remove --proxy-prometheus-insecure command line option

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,10 +66,6 @@ func run() {
 	viper.BindPFlag("proxy-auth-tls-verify", flags.Lookup("proxy-auth-tls-verify"))
 	viper.BindEnv("proxy-auth-tls-verify", "PROXY_AUTH_TLS_VERIFY")
 
-	flags.Bool("proxy-prometheus-insecure", true, "connect to prometheus and verify valid TLS")
-	viper.BindPFlag("proxy-prometheus-insecure", flags.Lookup("proxy-prometheus-tls-verify"))
-	viper.BindEnv("proxy-prometheus-insecure", "PROXY_PROMETHEUS_TLS_VERIFY")
-
 	flags.String("proxy-prometheus-base-url", "", "address of the prometheus to use for checking")
 	viper.BindPFlag("proxy-prometheus-base-url", flags.Lookup("proxy-prometheus-base-url"))
 	viper.BindEnv("proxy-prometheus-base-url", "PROXY_PROMETHEUS_BASE_URL")


### PR DESCRIPTION
There was a --proxy-prometheus-insecure command line option, but while the
help text matches that of --proxy-auth-tls-verify, the behavior was the
exact opposite.

Upon investigation, it turns out we're not using this value anywhere in the
code.

This commit removes the option in order to avoid confusion.
