### PR TITLE
Remove environment variable prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,6 @@ func main() {
 	registerStringFlag(flags, "proxy-project-key", "", "The project key to use for auth resources")
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-	viper.SetEnvPrefix("PROM_KEYCLOAK_PROXY")
 	viper.AutomaticEnv()
 
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
The config variables are already prefixed by PROXY_, and we don't need
to also prefix them by "PROM_KEYCLOAK_PROXY".
