### PR TITLE
Add Regexp to Querying

### DIFF
--- a/queries/parse.go
+++ b/queries/parse.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -63,8 +64,9 @@ func InjectMatcher(q url.Values, matcher *labels.Matcher) error {
 	return nil
 }
 
-func AppendMatcher(queryValues url.Values, queryValuesForAuth url.Values, key string, authKey string, defaultValue string) (string, error) {
+func AppendMatcher(queryValues url.Values, queryValuesForAuth url.Values, key string, authKey string, defaultValue string) (string, labels.MatchType, error) {
 	value := defaultValue
+	matchType := labels.MatchEqual
 	expr, exprErr := parser.ParseExpr(queryValues[QueryParam][0])
 	matchers := parser.ExtractSelectors(expr)
 	if exprErr != nil {
@@ -74,6 +76,7 @@ func AppendMatcher(queryValues url.Values, queryValuesForAuth url.Values, key st
 		for _, matcherSelector := range matcherSelector {
 			if matcherSelector.Name == key {
 				value = matcherSelector.Value
+				matchType = matcherSelector.Type
 			}
 		}
 	}
@@ -81,45 +84,102 @@ func AppendMatcher(queryValues url.Values, queryValuesForAuth url.Values, key st
 	if value != "" {
 		matcher := &labels.Matcher{
 			Name:  authKey,
-			Type:  labels.MatchRegexp,
+			Type:  matchType,
 			Value: LabelValuesToRegexpString([]string{value}),
 		}
 		err := InjectMatcher(queryValuesForAuth, matcher)
-		return value, err
+		return value, matchType, err
 	}
-	return value, nil
+	return value, matchType, nil
 }
 
-func ParseAuthorizations(hubKey string, clusterKey string, projectKey string, hub string, queryValues url.Values) (url.Values, []string, []string) {
-	queryValuesForAuth := make(url.Values)
+func findMatcherFromName(matchers []*labels.Matcher, name string) (*labels.Matcher) {
+	matcherIndex := slices.IndexFunc(matchers, func(m *labels.Matcher) (bool) {
+		return m.Name == name
+	})
+	if matcherIndex == -1 {
+		return nil
+	}
+	return matchers[matcherIndex]
+}
 
-	var authResourceNames []string
-	var authScopeNames []string
+func ParseAuthorizations(hubKey string, clusterKey string, projectKey string, hub string, matchers []*labels.Matcher) (string) {
+	resourceName := fmt.Sprintf("%s-%s", hubKey, hub)
 
-	authResourceNames = append(authResourceNames, hubKey)
-	authScopeNames = append(authScopeNames, "GET")
+	matcher := findMatcherFromName(matchers, "cluster")
+	if matcher.Value != "" {
+		if matcher.Type == labels.MatchRegexp {
+			resourceName = fmt.Sprintf("%s-%s-(%s)", resourceName, clusterKey, matcher.Value)
+		} else {
+			resourceName = fmt.Sprintf("%s-%s-%s", resourceName, clusterKey, matcher.Value)
+		}
 
-	authResourceNames = append(authResourceNames, fmt.Sprintf("%s-%s", hubKey, hub))
-	authScopeNames = append(authScopeNames, "GET")
+		exportedNamespaceMatcher := findMatcherFromName(matchers, "exported_namespace")
+		namespaceMatcher := findMatcherFromName(matchers, "namespace")
+		if exportedNamespaceMatcher == nil && namespaceMatcher == nil {
+			return resourceName
+		}
 
-	cluster, _ := AppendMatcher(queryValues, queryValuesForAuth, "cluster", fmt.Sprintf("%s-%s-%s", hubKey, hub, clusterKey), "")
-
-	if cluster != "" {
-		authResourceNames = append(authResourceNames, fmt.Sprintf("%s-%s-%s-%s", hubKey, hub, clusterKey, cluster))
-		authScopeNames = append(authScopeNames, "GET")
-
-		exported_namespace, _ := AppendMatcher(queryValues, queryValuesForAuth, "exported_namespace", fmt.Sprintf("%s-%s-%s-%s-%s", hubKey, hub, clusterKey, cluster, projectKey), "")
-		namespace, _ := AppendMatcher(queryValues, queryValuesForAuth, "namespace", fmt.Sprintf("%s-%s-%s-%s-%s", hubKey, hub, clusterKey, cluster, projectKey), exported_namespace)
-
-		if namespace != "" {
-			if cluster != "" {
-				authResourceNames = append(authResourceNames, fmt.Sprintf("%s-%s-%s-%s-%s-%s", hubKey, hub, clusterKey, cluster, projectKey, namespace))
-				authScopeNames = append(authScopeNames, "GET")
+		exportedNamespaceValue := "$^"
+		if exportedNamespaceMatcher != nil && exportedNamespaceMatcher.Value != "" {
+			if exportedNamespaceMatcher.Type == labels.MatchEqual {
+				exportedNamespaceValue = regexp.QuoteMeta(exportedNamespaceMatcher.Value)
+			} else {
+				exportedNamespaceValue = exportedNamespaceMatcher.Value
 			}
+		}
+
+		namespaceValue := "$^"
+		if namespaceMatcher != nil && namespaceMatcher.Value != "" {
+			if namespaceMatcher.Type == labels.MatchEqual {
+				namespaceValue = regexp.QuoteMeta(namespaceMatcher.Value)
+			} else {
+				namespaceValue = namespaceMatcher.Value
+			}
+		}
+
+		resourceName = fmt.Sprintf("%s-%s-(%s|%s)$", resourceName, projectKey, exportedNamespaceValue, namespaceValue)
+	}
+
+	return resourceName
+}
+
+func PromqlQueryFromResourceNames(metric string, resourceNames []string, hubKey string, clusterKey string, projectKey string) (string) {
+	clusters := make([]*string, len(resourceNames))
+	namespaces := make([]*string, len(resourceNames))
+
+	for i, _ := range resourceNames {
+		clusters[i] = nil
+		namespaces[i] = nil
+
+		re := regexp.MustCompile(fmt.Sprintf("^%s-([\\w-]+)-%s-([\\w-]+)-%s-([\\w-]+)$", hubKey, clusterKey, projectKey))
+		if matches := re.FindStringSubmatch(resourceNames[i]); matches != nil {
+			clusters[i] = &matches[2]
+			namespaces[i] = &matches[3]
+			continue
+		}
+
+		re = regexp.MustCompile(fmt.Sprintf("^%s-([\\w-]+)-%s-([\\w-]+)$", hubKey, clusterKey))
+		if matches := re.FindStringSubmatch(resourceNames[i]); matches != nil {
+			clusters[i] = &matches[2]
+			continue
 		}
 	}
 
-	return queryValuesForAuth, authResourceNames, authScopeNames
+	queries := make([]string, len(resourceNames))
+	for i := 0; i < len(resourceNames); i++ {
+		if clusters[i] != nil && namespaces != nil {
+			queries[i] = fmt.Sprintf("%s{cluster=\"%s\",namespace=\"%s\"}", metric, *clusters[i], *namespaces[i])
+		} else if clusters[i] != nil {
+			queries[i] = fmt.Sprintf("%s{cluster=\"%s\"}", metric, *clusters[i])
+		} else if namespaces[i] != nil {
+			queries[i] = fmt.Sprintf("%s{namespace=\"%s\"}", metric, *namespaces[i])
+		} else {
+			queries[i] = metric
+		}
+	}
+
+	return strings.Join(queries, " or ")
 }
 
 func QueryPrometheus(prometheusTlsCertPath string, prometheusTlsKeyPath string,

--- a/services/authService.go
+++ b/services/authService.go
@@ -7,13 +7,15 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/OCP-on-NERC/prom-keycloak-proxy/errors"
 	"github.com/OCP-on-NERC/prom-keycloak-proxy/queries"
+
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/Nerzal/gocloak/v13"
 	_ "github.com/gorilla/mux"
@@ -81,6 +83,7 @@ func Protect(hubKey string, clusterKey string, projectKey string, gocloakClient 
 			json.NewEncoder(w).Encode(errors.BadRequestError(err.Error())) //nolint:errcheck
 			return
 		}
+
 		username := *userInfo.PreferredUsername
 		var userClientId = ""
 		if strings.Contains(username, "service-account-") {
@@ -88,7 +91,6 @@ func Protect(hubKey string, clusterKey string, projectKey string, gocloakClient 
 		}
 
 		isTokenValid := *rptResult.Active
-
 		if !isTokenValid {
 			log.Warn().
 				Int("status", 401).
@@ -106,12 +108,26 @@ func Protect(hubKey string, clusterKey string, projectKey string, gocloakClient 
 		}
 
 		queryValues := r.URL.Query()
-		_, authResourceNames, authResourceScopes := queries.ParseAuthorizations(hubKey, clusterKey, projectKey, proxyAcmHub, queryValues)
-		var permissions []string
+		matchers, err := parser.ParseMetricSelector(r.URL.Query()["query"][0])
+		if err != nil {
+			log.Panic()
+		}
+		resourceName := queries.ParseAuthorizations(hubKey, clusterKey, projectKey, proxyAcmHub, matchers)
+		re, err := regexp.Compile(resourceName)
+		if err != nil {
+			log.Warn().
+				Int("status", 400).
+				Str("method", r.Method).
+				Str("path", r.RequestURI).
+				Str("ip", r.RemoteAddr).
+				Str("username", username).
+				Str("client-id", userClientId).
+				Str("query", query).
+				Msg("Bad Request")
 
-		for index, authResourceName := range authResourceNames {
-			authScopeName := authResourceScopes[index]
-			permissions = append(permissions, fmt.Sprintf("%s#%s", authResourceName, authScopeName))
+			w.WriteHeader(400)
+			json.NewEncoder(w).Encode(errors.BadRequestError(err.Error()))
+			return
 		}
 
 		rpp, err := gocloakClient.GetRequestingPartyPermissions(
@@ -120,10 +136,8 @@ func Protect(hubKey string, clusterKey string, projectKey string, gocloakClient 
 			authRealm,
 			gocloak.RequestingPartyTokenOptions{
 				Audience:    gocloak.StringP(authClientId),
-				Permissions: &permissions,
 			},
 		)
-
 		if err != nil {
 			log.Warn().
 				Int("status", 403).
@@ -157,54 +171,36 @@ func Protect(hubKey string, clusterKey string, projectKey string, gocloakClient 
 			return
 		}
 
-		var final_result = true
-		var unauthorized_key = ""
-		var unauthorized_value = ""
-		var current_result = false
-		for i, key := range authResourceNames {
-			value := authResourceScopes[i]
-			for _, permission := range *rpp {
-				if key == *permission.ResourceName && slices.Contains(*permission.Scopes, value) {
-					current_result = true
-					break
-				}
-			}
-			if !current_result {
-				unauthorized_key = key
-				unauthorized_value = value
+		// for all permissions associated with the token, if it matches the regex, add it to URL.values
+		// get a label.matcher from a ResourceName
+		var metricName string
+		for _, matcher := range matchers {
+			if matcher.Name == "__name__" {
+				metricName = matcher.Value
+				break
 			}
 		}
-		if !current_result {
-			final_result = false
+		var authorizedResourceNames []string
+		for _, permission := range *rpp {
+			if slices.Contains(*permission.Scopes, "GET") && re.MatchString(*permission.ResourceName) {
+				authorizedResourceNames = append(authorizedResourceNames, *permission.ResourceName)
+			}
 		}
 
-		if final_result {
-			log.Info().
-				Int("status", 200).
-				Str("method", r.Method).
-				Str("path", r.RequestURI).
-				Str("ip", r.RemoteAddr).
-				Str("username", username).
-				Str("client-id", userClientId).
-				Str("query", query).
-				RawJSON("permissions", out).
-				Msg("OK")
-		} else {
-			message := "You are not authorized to access the resource \"" + unauthorized_key + "\" with scope \"" + unauthorized_value + "\""
-			log.Warn().
-				Int("status", 403).
-				Str("method", r.Method).
-				Str("path", r.RequestURI).
-				Str("ip", r.RemoteAddr).
-				Str("username", username).
-				Str("client-id", userClientId).
-				Str("query", query).
-				Msg(message)
+		newQuery := queries.PromqlQueryFromResourceNames(metricName, authorizedResourceNames, hubKey, clusterKey, projectKey)
+		queryValues.Set("query", newQuery)
+		r.URL.RawQuery = queryValues.Encode()
 
-			w.WriteHeader(403)
-			json.NewEncoder(w).Encode(errors.HttpError{Code: 403, Error: "Forbidden", Message: message}) //nolint:errcheck
-			return
-		}
+		log.Info().
+			Int("status", 200).
+			Str("method", r.Method).
+			Str("path", r.RequestURI).
+			Str("ip", r.RemoteAddr).
+			Str("username", username).
+			Str("client-id", userClientId).
+			Str("query", query).
+			RawJSON("permissions", out).
+			Msg("OK")
 
 		// Our middleware logic goes here...
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
Currently, prom-keycloak-proxy only supports single equality label matching. This limits the user if they want to retrieve metrics from multiple different clusters and namespaces. This update gives the user that capability.