### PR TITLE
openshift local support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type ProxyConfig struct {
 	PrometheusTlsCert  string   `validate:"omitempty,file"`
 	PrometheusTlsKey   string   `validate:"omitempty,file"`
 	PrometheusToken    string   `validate:"omitempty,ascii"`
+	OpenshiftLocal     bool     `validate:"boolean"`
 }
 
 // NewValidator returns a new validator with our custom
@@ -64,5 +65,6 @@ func BuildFromViper(v ViperInterface) *ProxyConfig {
 		PrometheusTlsCert:  v.GetString("proxy-prometheus-tls-cert"),
 		PrometheusTlsKey:   v.GetString("proxy-prometheus-tls-key"),
 		PrometheusToken:    v.GetString("proxy-prometheus-token"),
+		OpenshiftLocal:     v.GetBool("openshift-local"),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 			cfg.AuthClientId,
 			cfg.AuthClientSecret,
 			cfg.AcmHub,
+			cfg.OpenshiftLocal,
 			services.PromQueryHandler(
 				gocloakClient,
 				cfg.AuthRealm,
@@ -117,6 +118,7 @@ func rootRunE(cmd *cobra.Command, args []string) error {
 				cfg.PrometheusTlsKey,
 				cfg.PrometheusCaCert,
 				cfg.PrometheusToken,
+				cfg.OpenshiftLocal,
 				cfg.AuthTlsVerify))))
 	go func() {
 		if err := cobrautil.HTTPListenFromFlags(cmd, proxyPrefix, proxySrv, zerolog.InfoLevel); err != nil {

--- a/services/authService.go
+++ b/services/authService.go
@@ -14,7 +14,6 @@ import (
 	"github.com/OCP-on-NERC/prom-keycloak-proxy/errors"
 	"github.com/OCP-on-NERC/prom-keycloak-proxy/queries"
 
-
 	"github.com/Nerzal/gocloak/v13"
 	_ "github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
@@ -35,7 +34,7 @@ func InitializeOauthServer(authBaseUrl string, authTlsVerify bool) *gocloak.GoCl
 	return client
 }
 
-func Protect(hubKey string, clusterKey string, projectKey string, gocloakClient *gocloak.GoCloak, authRealm string, authClientId string, authClientSecret string, proxyAcmHub string, next http.Handler) http.Handler {
+func Protect(hubKey string, clusterKey string, projectKey string, gocloakClient *gocloak.GoCloak, authRealm string, authClientId string, authClientSecret string, proxyAcmHub string, openshiftLocal bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query().Get(queries.QueryParam)
 
@@ -106,7 +105,7 @@ func Protect(hubKey string, clusterKey string, projectKey string, gocloakClient 
 		}
 
 		queryValues := r.URL.Query()
-		parsedResourceNameGroups, permissions := queries.ParseAuthorizations(hubKey, clusterKey, projectKey, proxyAcmHub, queryValues["query"][0])
+		parsedResourceNameGroups, permissions := queries.ParseAuthorizations(hubKey, clusterKey, projectKey, proxyAcmHub, openshiftLocal, queryValues["query"][0])
 		rpp, err := gocloakClient.GetRequestingPartyPermissions(
 			context.Background(),
 			accessToken,

--- a/services/promService.go
+++ b/services/promService.go
@@ -14,7 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func PromQueryHandler(gocloakClient *gocloak.GoCloak, authRealm string, authClientId string, prometheusBaseUrl string, prometheusTlsCertPath string, prometheusTlsKeyPath string, prometheusCaCertPath string, prometheusToken string, authTlsVerify bool) http.HandlerFunc {
+func PromQueryHandler(gocloakClient *gocloak.GoCloak, authRealm string, authClientId string, prometheusBaseUrl string, prometheusTlsCertPath string, prometheusTlsKeyPath string, prometheusCaCertPath string, prometheusToken string, openshiftLocal bool, authTlsVerify bool) http.HandlerFunc {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			queryValues := r.URL.Query()


### PR DESCRIPTION
- **Add OpenshiftLocal param to ignore cluster filter**

Because OpenShift Local and single cluster deployments connected to prometheus do not use a cluster filter in metrics, it requires a switch to enable OpenShift Local support.